### PR TITLE
fix(src/prime.go): refactor go codes, optimaze it

### DIFF
--- a/src/prime.go
+++ b/src/prime.go
@@ -1,34 +1,29 @@
 package main
 
 import (
-    "fmt"
-    "math"
-    "time"
+	"fmt"
+	"math"
+	"time"
 )
 
 func isPrime(n int) bool {
-    if n <= 1 {
-        return false
-    }
+	if n <= 1 {
+		return false
+	}
 
-    end := int(math.Sqrt(float64(n)))
-    for i := 2; i <= end; i++ {
-        if n%i == 0 {
-            return false
-        }
-    }
-    return true
+	end := int(math.Sqrt(float64(n)))
+	for i := 2; i <= end && n%i == 0; i++ {
+		return false
+	}
+	return true
 }
 
 func main() {
-    start := float64(time.Now(). UnixMilli()) 
-    c := 0
-    for i := 0; i < 9000000; i++ {
-        if isPrime(i) {
-            c++
-        }
-    }
-    fmt.Println(c)
-    end := float64(time.Now().UnixMilli())
-    fmt.Printf("%vms", end-start)
+	start := time.Now()
+	c := 0
+	for i := 0; i < 9000000 && isPrime(i); i++ {
+		c++
+	}
+	fmt.Println(c)
+	fmt.Printf("%vms", time.Since(start).Milliseconds())
 }


### PR DESCRIPTION
It's seem that go version code is slower than python and js and it didn't make sense for me, so I looked at the code and for some reason if statement inside a loop make the code slower so I rewrite it and move the if statement to for conventional statement. here is the benchmark result I've got for before and after the change:

before: 
BenchmarkPrime-8   	311378482	         3.755 ns/op	       0 B/op	       0 allocs/op

after:
BenchmarkPrime-8   	1000000000	         0.3114 ns/op	       0 B/op	       0 allocs/op

it's like the updated code is 10x faster than the old one.