### PR TITLE
Go: changed variable types and strip additional info from the binary 

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -95,7 +95,7 @@ echo ""
 
 echo "*-------------- go ---------------*"
 go version
-go build ./src/prime.go
+go build -ldflags "-s -w" ./src/prime.go
 
 sleep 5 # cpu cool down
 

--- a/src/prime.go
+++ b/src/prime.go
@@ -1,34 +1,36 @@
 package main
 
 import (
-    "fmt"
-    "math"
-    "time"
+	"fmt"
+	"math"
+	"time"
 )
 
-func isPrime(n int) bool {
-    if n <= 1 {
-        return false
-    }
+func isPrime(n uint32) bool {
+	if n <= 1 {
+		return false
+	}
 
-    end := int(math.Sqrt(float64(n)))
-    for i := 2; i <= end; i++ {
-        if n%i == 0 {
-            return false
-        }
-    }
-    return true
+	end := uint32(math.Sqrt(float64(n)))
+	var i uint32
+	for i = 2; i <= end; i++ {
+		if n%i == 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func main() {
-    start := float64(time.Now(). UnixMilli()) 
-    c := 0
-    for i := 0; i < 9000000; i++ {
-        if isPrime(i) {
-            c++
-        }
-    }
-    fmt.Println(c)
-    end := float64(time.Now().UnixMilli())
-    fmt.Printf("%vms", end-start)
+	start := float64(time.Now().UnixMilli())
+	c := 0
+	var i uint32
+	for i = 0; i < 9000000; i++ {
+		if isPrime(i) {
+			c++
+		}
+	}
+	fmt.Println(c)
+	end := float64(time.Now().UnixMilli())
+	fmt.Printf("%vms", end-start)
 }


### PR DESCRIPTION
In Go, your choice of variable's type can be critical for performance. I used uint32 instead of int which resulted in drastic improvement.

Also, I removed symbol table and DWARF generation from the final binary which may or may not affect the performance.