### PR TITLE
fix: speed up go algorithm

### DIFF
--- a/src/prime.go
+++ b/src/prime.go
@@ -24,6 +24,7 @@ func isPrime(n int32) bool {
 func main() {
 	start := time.Now()
 	c := 0
+
 	var i int32
 	for i = 0; i < 9000000; i++ {
 		if isPrime(i) {
@@ -32,7 +33,6 @@ func main() {
 	}
 	fmt.Println(c)
 
-	end := time.Since(start).String()
-
-	fmt.Println(end)
+	duration := time.Since(start)
+	fmt.Printf("%s\n", duration)
 }

--- a/src/prime.go
+++ b/src/prime.go
@@ -1,34 +1,38 @@
 package main
 
 import (
-    "fmt"
-    "math"
-    "time"
+	"fmt"
+	"math"
+	"time"
 )
 
-func isPrime(n int) bool {
-    if n <= 1 {
-        return false
-    }
+func isPrime(n int32) bool {
+	if n <= 1 {
+		return false
+	}
 
-    end := int(math.Sqrt(float64(n)))
-    for i := 2; i <= end; i++ {
-        if n%i == 0 {
-            return false
-        }
-    }
-    return true
+	end := int32(math.Sqrt(float64(n)))
+	var i int32
+	for i = 2; i <= end; i++ {
+		if n%i == 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func main() {
-    start := float64(time.Now(). UnixMilli()) 
-    c := 0
-    for i := 0; i < 9000000; i++ {
-        if isPrime(i) {
-            c++
-        }
-    }
-    fmt.Println(c)
-    end := float64(time.Now().UnixMilli())
-    fmt.Printf("%vms", end-start)
+	start := time.Now()
+	c := 0
+	var i int32
+	for i = 0; i < 9000000; i++ {
+		if isPrime(i) {
+			c++
+		}
+	}
+	fmt.Println(c)
+
+	end := time.Since(start).String()
+
+	fmt.Println(end)
 }


### PR DESCRIPTION
You use `int` and it is converted to `int64` in most of the machines which requires a lot RAM.
I changed it to `int32` and here are the results.

Before: `~10.5s`.

Now: `~2.8s` in 4 runs on my local.

I didn't change the algorithm at all.

P.S. it is also possible to change it to `uint32`.